### PR TITLE
Include license in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The MIT license requires all copies of the program include the license.