### PR TITLE
fix: check other's type before accessing other's properties

### DIFF
--- a/docs/praatio/data_classes/data_point.html
+++ b/docs/praatio/data_classes/data_point.html
@@ -110,7 +110,7 @@ data.</p>
 <span class="kn">from</span> <span class="nn">praatio.utilities</span> <span class="kn">import</span> <span class="n">errors</span>
 
 
-<span class="k">class</span> <span class="nc">PointObject</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+<span class="k">class</span> <span class="nc">PointObject</span><span class="p">:</span>
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">pointList</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">Tuple</span><span class="p">[</span><span class="nb">float</span><span class="p">,</span> <span class="o">...</span><span class="p">]],</span>
@@ -124,6 +124,9 @@ data.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">maxTime</span> <span class="o">=</span> <span class="n">maxTime</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">PointObject</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">objectClass</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">objectClass</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">minTime</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">minTime</span>
@@ -237,7 +240,7 @@ data.</p>
 
                 <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">PointObject</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">PointObject</span><span class="p">:</span>
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">pointList</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">Tuple</span><span class="p">[</span><span class="nb">float</span><span class="p">,</span> <span class="o">...</span><span class="p">]],</span>
@@ -251,6 +254,9 @@ data.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">maxTime</span> <span class="o">=</span> <span class="n">maxTime</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">PointObject</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">objectClass</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">objectClass</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">minTime</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">minTime</span>

--- a/docs/praatio/data_classes/interval_tier.html
+++ b/docs/praatio/data_classes/interval_tier.html
@@ -2597,11 +2597,17 @@ maxTimestamp in the tier and the current textgrid.</li>
             <summary>View Source</summary>
             <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Interval</span><span class="p">(</span><span class="n">namedtuple</span><span class="p">(</span><span class="s2">&quot;Interval&quot;</span><span class="p">,</span> <span class="p">[</span><span class="s2">&quot;start&quot;</span><span class="p">,</span> <span class="s2">&quot;end&quot;</span><span class="p">,</span> <span class="s2">&quot;label&quot;</span><span class="p">])):</span>
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Interval</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="k">return</span> <span class="p">(</span>
             <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">start</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">start</span><span class="p">)</span>
             <span class="ow">and</span> <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">end</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">end</span><span class="p">)</span>
             <span class="ow">and</span> <span class="bp">self</span><span class="o">.</span><span class="n">label</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">label</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__ne__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span> <span class="o">==</span> <span class="n">other</span>
 </pre></div>
 
         </details>

--- a/docs/praatio/data_classes/klattgrid.html
+++ b/docs/praatio/data_classes/klattgrid.html
@@ -145,7 +145,7 @@
 <span class="kn">from</span> <span class="nn">praatio.utilities</span> <span class="kn">import</span> <span class="n">errors</span>
 
 
-<span class="k">class</span> <span class="nc">_KlattBaseTier</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+<span class="k">class</span> <span class="nc">_KlattBaseTier</span><span class="p">:</span>
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">tierNameList</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>  <span class="c1"># Preserves the order of the tiers</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">tierDict</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="s2">&quot;_KlattBaseTier&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="p">{}</span>
@@ -154,6 +154,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">maxTimestamp</span> <span class="o">=</span> <span class="kc">None</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">_KlattBaseTier</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">minTimestamp</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">minTimestamp</span>

--- a/docs/praatio/data_classes/point_tier.html
+++ b/docs/praatio/data_classes/point_tier.html
@@ -1648,10 +1648,16 @@ maxTimestamp in the tier and the current textgrid.</li>
             <summary>View Source</summary>
             <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Point</span><span class="p">(</span><span class="n">namedtuple</span><span class="p">(</span><span class="s2">&quot;Point&quot;</span><span class="p">,</span> <span class="p">[</span><span class="s2">&quot;time&quot;</span><span class="p">,</span> <span class="s2">&quot;label&quot;</span><span class="p">])):</span>
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Point</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="k">return</span> <span class="p">(</span>
             <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">time</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">time</span><span class="p">,</span> <span class="n">abs_tol</span><span class="o">=</span><span class="mf">1e-14</span><span class="p">)</span>
             <span class="ow">and</span> <span class="bp">self</span><span class="o">.</span><span class="n">label</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">label</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__ne__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span> <span class="o">==</span> <span class="n">other</span>
 </pre></div>
 
         </details>

--- a/docs/praatio/data_classes/textgrid.html
+++ b/docs/praatio/data_classes/textgrid.html
@@ -152,6 +152,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="n">maxTimestamp</span>  <span class="c1"># type: ignore[assignment]</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Textgrid</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="n">my_math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">)</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="n">my_math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
@@ -699,6 +702,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="n">maxTimestamp</span>  <span class="c1"># type: ignore[assignment]</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Textgrid</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="n">my_math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">)</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="n">my_math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>

--- a/docs/praatio/data_classes/textgrid_tier.html
+++ b/docs/praatio/data_classes/textgrid_tier.html
@@ -147,6 +147,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">errorReporter</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">getErrorReporter</span><span class="p">(</span><span class="n">errorMode</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="nb">type</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">!=</span> <span class="nb">type</span><span class="p">(</span><span class="n">other</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">)</span>
@@ -381,6 +384,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">errorReporter</span> <span class="o">=</span> <span class="n">utils</span><span class="o">.</span><span class="n">getErrorReporter</span><span class="p">(</span><span class="n">errorMode</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="nb">type</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">!=</span> <span class="nb">type</span><span class="p">(</span><span class="n">other</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="n">isEqual</span> <span class="o">=</span> <span class="kc">True</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
         <span class="n">isEqual</span> <span class="o">&amp;=</span> <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">)</span>

--- a/docs/praatio/utilities/constants.html
+++ b/docs/praatio/utilities/constants.html
@@ -275,19 +275,31 @@
 <span class="c1"># https://stackoverflow.com/questions/34570814/equality-overloading-for-namedtuple</span>
 <span class="k">class</span> <span class="nc">Interval</span><span class="p">(</span><span class="n">namedtuple</span><span class="p">(</span><span class="s2">&quot;Interval&quot;</span><span class="p">,</span> <span class="p">[</span><span class="s2">&quot;start&quot;</span><span class="p">,</span> <span class="s2">&quot;end&quot;</span><span class="p">,</span> <span class="s2">&quot;label&quot;</span><span class="p">])):</span>
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Interval</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="k">return</span> <span class="p">(</span>
             <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">start</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">start</span><span class="p">)</span>
             <span class="ow">and</span> <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">end</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">end</span><span class="p">)</span>
             <span class="ow">and</span> <span class="bp">self</span><span class="o">.</span><span class="n">label</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">label</span>
         <span class="p">)</span>
 
+    <span class="k">def</span> <span class="fm">__ne__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span> <span class="o">==</span> <span class="n">other</span>
+
 
 <span class="k">class</span> <span class="nc">Point</span><span class="p">(</span><span class="n">namedtuple</span><span class="p">(</span><span class="s2">&quot;Point&quot;</span><span class="p">,</span> <span class="p">[</span><span class="s2">&quot;time&quot;</span><span class="p">,</span> <span class="s2">&quot;label&quot;</span><span class="p">])):</span>
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Point</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="k">return</span> <span class="p">(</span>
             <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">time</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">time</span><span class="p">,</span> <span class="n">abs_tol</span><span class="o">=</span><span class="mf">1e-14</span><span class="p">)</span>
             <span class="ow">and</span> <span class="bp">self</span><span class="o">.</span><span class="n">label</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">label</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__ne__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span> <span class="o">==</span> <span class="n">other</span>
 
 
 <span class="n">MIN_INTERVAL_LENGTH</span><span class="p">:</span> <span class="n">Final</span> <span class="o">=</span> <span class="mf">0.00000001</span>  <span class="c1"># Arbitrary threshold</span>
@@ -391,11 +403,17 @@
             <summary>View Source</summary>
             <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Interval</span><span class="p">(</span><span class="n">namedtuple</span><span class="p">(</span><span class="s2">&quot;Interval&quot;</span><span class="p">,</span> <span class="p">[</span><span class="s2">&quot;start&quot;</span><span class="p">,</span> <span class="s2">&quot;end&quot;</span><span class="p">,</span> <span class="s2">&quot;label&quot;</span><span class="p">])):</span>
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Interval</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="k">return</span> <span class="p">(</span>
             <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">start</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">start</span><span class="p">)</span>
             <span class="ow">and</span> <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">end</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">end</span><span class="p">)</span>
             <span class="ow">and</span> <span class="bp">self</span><span class="o">.</span><span class="n">label</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">label</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__ne__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span> <span class="o">==</span> <span class="n">other</span>
 </pre></div>
 
         </details>
@@ -474,10 +492,16 @@
             <summary>View Source</summary>
             <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Point</span><span class="p">(</span><span class="n">namedtuple</span><span class="p">(</span><span class="s2">&quot;Point&quot;</span><span class="p">,</span> <span class="p">[</span><span class="s2">&quot;time&quot;</span><span class="p">,</span> <span class="s2">&quot;label&quot;</span><span class="p">])):</span>
     <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Point</span><span class="p">):</span>
+            <span class="k">return</span> <span class="kc">False</span>
+
         <span class="k">return</span> <span class="p">(</span>
             <span class="n">math</span><span class="o">.</span><span class="n">isclose</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">time</span><span class="p">,</span> <span class="n">other</span><span class="o">.</span><span class="n">time</span><span class="p">,</span> <span class="n">abs_tol</span><span class="o">=</span><span class="mf">1e-14</span><span class="p">)</span>
             <span class="ow">and</span> <span class="bp">self</span><span class="o">.</span><span class="n">label</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">label</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__ne__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span> <span class="o">==</span> <span class="n">other</span>
 </pre></div>
 
         </details>

--- a/praatio/data_classes/data_point.py
+++ b/praatio/data_classes/data_point.py
@@ -17,7 +17,7 @@ from praatio.utilities import constants
 from praatio.utilities import errors
 
 
-class PointObject(object):
+class PointObject:
     def __init__(
         self,
         pointList: List[Tuple[float, ...]],
@@ -31,6 +31,9 @@ class PointObject(object):
         self.maxTime = maxTime
 
     def __eq__(self, other):
+        if not isinstance(other, PointObject):
+            return False
+
         isEqual = True
         isEqual &= self.objectClass == other.objectClass
         isEqual &= self.minTime == other.minTime

--- a/praatio/data_classes/klattgrid.py
+++ b/praatio/data_classes/klattgrid.py
@@ -12,7 +12,7 @@ from praatio.data_classes import textgrid_tier
 from praatio.utilities import errors
 
 
-class _KlattBaseTier(object):
+class _KlattBaseTier:
     def __init__(self, name: str):
         self.tierNameList: List[str] = []  # Preserves the order of the tiers
         self.tierDict: Dict[str, "_KlattBaseTier"] = {}
@@ -21,6 +21,9 @@ class _KlattBaseTier(object):
         self.maxTimestamp = None
 
     def __eq__(self, other):
+        if not isinstance(other, _KlattBaseTier):
+            return False
+
         isEqual = True
         isEqual &= self.name == other.name
         isEqual &= self.minTimestamp == other.minTimestamp

--- a/praatio/data_classes/textgrid.py
+++ b/praatio/data_classes/textgrid.py
@@ -49,6 +49,9 @@ class Textgrid:
         self.maxTimestamp: float = maxTimestamp  # type: ignore[assignment]
 
     def __eq__(self, other):
+        if not isinstance(other, Textgrid):
+            return False
+
         isEqual = True
         isEqual &= my_math.isclose(self.minTimestamp, other.minTimestamp)
         isEqual &= my_math.isclose(self.maxTimestamp, other.maxTimestamp)

--- a/praatio/data_classes/textgrid_tier.py
+++ b/praatio/data_classes/textgrid_tier.py
@@ -49,6 +49,9 @@ class TextgridTier(ABC):
         self.errorReporter = utils.getErrorReporter(errorMode)
 
     def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+
         isEqual = True
         isEqual &= self.name == other.name
         isEqual &= math.isclose(self.minTimestamp, other.minTimestamp)

--- a/praatio/utilities/constants.py
+++ b/praatio/utilities/constants.py
@@ -12,19 +12,31 @@ POINT_TIER: Final = "TextTier"
 # https://stackoverflow.com/questions/34570814/equality-overloading-for-namedtuple
 class Interval(namedtuple("Interval", ["start", "end", "label"])):
     def __eq__(self, other):
+        if not isinstance(other, Interval):
+            return False
+
         return (
             math.isclose(self.start, other.start)
             and math.isclose(self.end, other.end)
             and self.label == other.label
         )
 
+    def __ne__(self, other):
+        return not self == other
+
 
 class Point(namedtuple("Point", ["time", "label"])):
     def __eq__(self, other):
+        if not isinstance(other, Point):
+            return False
+
         return (
             math.isclose(self.time, other.time, abs_tol=1e-14)
             and self.label == other.label
         )
+
+    def __ne__(self, other):
+        return not self == other
 
 
 MIN_INTERVAL_LENGTH: Final = 0.00000001  # Arbitrary threshold

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import io
 setup(
     name="praatio",
     python_requires=">3.6.0",
-    version="5.1.0",
+    version="5.1.1",
     author="Tim Mahrt",
     author_email="timmahrt@gmail.com",
     url="https://github.com/timmahrt/praatIO",

--- a/tests/test_interval_tier.py
+++ b/tests/test_interval_tier.py
@@ -16,6 +16,10 @@ def makeIntervalTier(name="words", intervals=None, minT=0, maxT=5.0):
 
 
 class TestIntervalTier(PraatioTestCase):
+    def test_inequivalence_with_non_point_tiers(self):
+        sut = makeIntervalTier()
+        self.assertNotEqual(sut, 55)
+
     def test_creating_an_interval_tier_with_invalid_intervals_raises_an_error(self):
         with self.assertRaises(errors.TextgridStateError) as _:
             textgrid.IntervalTier(

--- a/tests/test_point_tier.py
+++ b/tests/test_point_tier.py
@@ -15,6 +15,10 @@ def makePointTier(name="pitch_values", points=None, minT=0, maxT=5.0):
 
 
 class TestPointTier(PraatioTestCase):
+    def test_inequivalence_with_non_point_tiers(self):
+        sut = makePointTier()
+        self.assertNotEqual(sut, 55)
+
     def test_append_tier_with_mixed_type_throws_exception(self):
         pointTier = makePointTier()
         intervalTier = textgrid.IntervalTier(

--- a/tests/test_textgrid.py
+++ b/tests/test_textgrid.py
@@ -21,6 +21,10 @@ def makePointTier(name="pitch_values", points=None, minT=0, maxT=5.0):
 
 
 class TestTextgrid(PraatioTestCase):
+    def test_inequivalence_with_non_textgrids(self):
+        sut = textgrid.Textgrid()
+        self.assertNotEqual(sut, 55)
+
     def test_add_tier_raises_error_with_invalid_option(self):
         sut = textgrid.Textgrid()
         tier = makeIntervalTier()

--- a/tests/utilities/test_constants.py
+++ b/tests/utilities/test_constants.py
@@ -23,6 +23,10 @@ class TestConstants(PraatioTestCase):
             constants.Interval(0.5555555556, 1.0, "hello"),
             constants.Interval(5 / 9.0, 1.0, "hello"),
         )
+        self.assertNotEqual(
+            constants.Interval(5 / 9.0, 1.0, "hello"), (0.5555555556, 1.0, "hello")
+        )
+        self.assertNotEqual(constants.Interval(5 / 9.0, 1.0, "hello"), "hello")
 
     def test_point_as_named_tuple(self):
         sut = constants.Point(0.5, "hello")
@@ -38,3 +42,6 @@ class TestConstants(PraatioTestCase):
             constants.Point(0.5555555556, "hello"),
             constants.Point(5 / 9.0, "hello"),
         )
+
+        self.assertNotEqual(constants.Point(5 / 9.0, "hello"), (5 / 9.0, "hello"))
+        self.assertNotEqual(constants.Point(5 / 9.0, "hello"), "hello")


### PR DESCRIPTION
An unhandled exception occurs if the user attempts to do something like:

```
tg1 = Textgrid()
tg2 = 5

if tg1 == tg2:
...
```

This is because in the custom equality check methods, I assume both things have the same properties--if one is not, then accessing one of the properties causes an exception.

Now, in all `__eq__` methods, I now first verify that the two things are of the same type. 