### PR TITLE
feat: add dejitter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 *Praatio uses semantic versioning (Major.Minor.Patch)*
 
+Ver 6.1 (Feb 6, 2023)
+- Add `TextgridTier.dejitter()` method for improving consistency between tiers
+
 Ver 6.0 (Feb 4, 2023)
 - Refactored 'audio.py' for maintainability (see [UPGRADING.md](https://github.com/timmahrt/praatIO/blob/main/UPGRADING.md) for details)
 - Added unit tests for 'audio.py'

--- a/praatio/data_classes/interval_tier.py
+++ b/praatio/data_classes/interval_tier.py
@@ -99,6 +99,23 @@ class IntervalTier(textgrid_tier.TextgridTier):
                     f"({entry.start}, {entry.end}, {entry.label}) and ({entry.start}, {entry.end}, {entry.label})"
                 )
 
+    @property
+    def timestamps(self) -> List[float]:
+        """All unique timestamps used in this tier"""
+        tmpTimestamps = [
+            time
+            for start, stop, _ in self.entries
+            for time in [
+                start,
+                stop,
+            ]
+        ]
+
+        uniqueTimestamps = list(set(tmpTimestamps))
+        uniqueTimestamps.sort()
+
+        return uniqueTimestamps
+
     def crop(
         self,
         cropStart: float,
@@ -154,6 +171,40 @@ class IntervalTier(textgrid_tier.TextgridTier):
         croppedTier = IntervalTier(self.name, newEntryList, minT, maxT)
 
         return croppedTier
+
+    def dejitter(
+        self, referenceTier: textgrid_tier.TextgridTier, maxDifference: float = 0.001
+    ) -> textgrid_tier.TextgridTier:
+        """
+        Set timestamps in this tier to be the same as values in the reference tier
+
+        Timestamps will only be moved if they are less than maxDifference away from the
+        reference time.
+
+        This can be used to correct minor alignment errors between tiers, as made when
+        annotating files manually, etc.
+
+        Args:
+            referenceTier: the IntervalTier or PointTier to use as a reference
+            maxDifference: the maximum amount to allow timestamps to be moved by
+
+        Returns:
+            the modified version of the current tier
+        """
+        referenceTimestamps = referenceTier.timestamps
+
+        newEntries = []
+        for start, stop, label in self.entries:
+            startCompare = min(referenceTimestamps, key=lambda x: abs(x - start))
+            stopCompare = min(referenceTimestamps, key=lambda x: abs(x - stop))
+
+            if abs(start - startCompare) <= maxDifference:
+                start = startCompare
+            if abs(stop - stopCompare) <= maxDifference:
+                stop = stopCompare
+            newEntries.append((start, stop, label))
+
+        return self.new(entries=newEntries)
 
     def deleteEntry(self, entry: Interval) -> None:
         """Removes an entry from the entries"""

--- a/praatio/data_classes/interval_tier.py
+++ b/praatio/data_classes/interval_tier.py
@@ -14,6 +14,7 @@ from praatio.utilities.constants import (
 
 from praatio.utilities import errors
 from praatio.utilities import utils
+from praatio.utilities import my_math
 from praatio.utilities import constants
 
 from praatio.data_classes import textgrid_tier
@@ -173,7 +174,9 @@ class IntervalTier(textgrid_tier.TextgridTier):
         return croppedTier
 
     def dejitter(
-        self, referenceTier: textgrid_tier.TextgridTier, maxDifference: float = 0.001
+        self,
+        referenceTier: textgrid_tier.TextgridTier,
+        maxDifference: float = 0.001,
     ) -> textgrid_tier.TextgridTier:
         """
         Set timestamps in this tier to be the same as values in the reference tier
@@ -198,9 +201,9 @@ class IntervalTier(textgrid_tier.TextgridTier):
             startCompare = min(referenceTimestamps, key=lambda x: abs(x - start))
             stopCompare = min(referenceTimestamps, key=lambda x: abs(x - stop))
 
-            if abs(start - startCompare) <= maxDifference:
+            if my_math.lessThanOrEqual(abs(start - startCompare), maxDifference):
                 start = startCompare
-            if abs(stop - stopCompare) <= maxDifference:
+            if my_math.lessThanOrEqual(abs(stop - stopCompare), maxDifference):
                 stop = stopCompare
             newEntries.append((start, stop, label))
 

--- a/praatio/data_classes/klattgrid.py
+++ b/praatio/data_classes/klattgrid.py
@@ -138,6 +138,9 @@ class KlattPointTier(textgrid_tier.TextgridTier):
     def crop(self):
         raise NotImplementedError
 
+    def dejitter(self):
+        raise NotImplementedError
+
     def deleteEntry(self, entry):
         raise NotImplementedError
 
@@ -153,6 +156,10 @@ class KlattPointTier(textgrid_tier.TextgridTier):
     def insertSpace(self):
         raise NotImplementedError
 
+    @property
+    def timestamps(self):
+        raise NotImplementedError
+
     def validate(self):
         raise NotImplementedError
 
@@ -161,7 +168,7 @@ class KlattPointTier(textgrid_tier.TextgridTier):
             (timestamp, modFunc(float(value))) for timestamp, value in self.entries
         ]
 
-        self.entries = newEntries
+        self._entries = newEntries
 
     def getAsText(self) -> str:
         outputList = []

--- a/praatio/data_classes/point_tier.py
+++ b/praatio/data_classes/point_tier.py
@@ -12,6 +12,7 @@ from praatio.utilities.constants import (
 from praatio.utilities import constants
 from praatio.utilities import errors
 from praatio.utilities import utils
+from praatio.utilities import my_math
 
 from praatio.data_classes import textgrid_tier
 
@@ -156,7 +157,7 @@ class PointTier(textgrid_tier.TextgridTier):
         for time, label in self.entries:
             timeCompare = min(referenceTimestamps, key=lambda x: abs(x - time))
 
-            if abs(time - timeCompare) <= maxDifference:
+            if my_math.lessThanOrEqual(abs(time - timeCompare), maxDifference):
                 time = timeCompare
             newEntries.append((time, label))
 

--- a/praatio/data_classes/point_tier.py
+++ b/praatio/data_classes/point_tier.py
@@ -72,6 +72,16 @@ class PointTier(textgrid_tier.TextgridTier):
 
         super(PointTier, self).__init__(name, entries, calculatedMinT, calculatedMaxT)
 
+    @property
+    def timestamps(self) -> List[float]:
+        """All unique timestamps used in this tier"""
+        tmpTimestamps = [time for time, _ in self.entries]
+
+        uniqueTimestamps = list(set(tmpTimestamps))
+        uniqueTimestamps.sort()
+
+        return uniqueTimestamps
+
     def crop(
         self,
         cropStart: float,
@@ -120,6 +130,37 @@ class PointTier(textgrid_tier.TextgridTier):
     def deleteEntry(self, entry: Point) -> None:
         """Removes an entry from the entries"""
         self._entries.pop(self._entries.index(entry))
+
+    def dejitter(
+        self, referenceTier: textgrid_tier.TextgridTier, maxDifference: float = 0.001
+    ) -> "PointTier":
+        """
+        Set timestamps in this tier to be the same as values in the reference tier
+
+        Timestamps will only be moved if they are less than maxDifference away from the
+        reference time.
+
+        This can be used to correct minor alignment errors between tiers, as made when
+        annotating files manually, etc.
+
+        Args:
+            referenceTier: the IntervalTier or PointTier to use as a reference
+            maxDifference: the maximum amount to allow timestamps to be moved by
+
+        Returns:
+            the modified version of the current tier
+        """
+        referenceTimestamps = referenceTier.timestamps
+
+        newEntries = []
+        for time, label in self.entries:
+            timeCompare = min(referenceTimestamps, key=lambda x: abs(x - time))
+
+            if abs(time - timeCompare) <= maxDifference:
+                time = timeCompare
+            newEntries.append((time, label))
+
+        return self.new(entries=newEntries)
 
     def editTimestamps(
         self,

--- a/praatio/data_classes/textgrid_tier.py
+++ b/praatio/data_classes/textgrid_tier.py
@@ -75,6 +75,11 @@ class TextgridTier(ABC):
     def entries(self):
         return tuple(self._entries)
 
+    @property
+    @abstractmethod
+    def timestamps(self) -> List[float]:
+        pass
+
     def appendTier(self, tier: "TextgridTier") -> "TextgridTier":
         """Append a tier to the end of this one.
 
@@ -207,6 +212,14 @@ class TextgridTier(ABC):
         collisionMode: Literal["replace", "merge", "error"] = "error",
         collisionReportingMode: Literal["silence", "warning"] = "warning",
     ) -> None:  # pragma: no cover
+        pass
+
+    @abstractmethod
+    def dejitter(
+        self,
+        referenceTier: "TextgridTier",
+        maxDifference: float = 0.001,
+    ) -> "TextgridTier":  # pragma: no cover
         pass
 
     @abstractmethod

--- a/praatio/utilities/my_math.py
+++ b/praatio/utilities/my_math.py
@@ -21,6 +21,10 @@ def isclose(a: float, b: float, rel_tol: float = 1e-14, abs_tol: float = 0.0) ->
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
+def lessThanOrEqual(a: float, b: float):
+    return isclose(a, b) or a < b
+
+
 def filterTimeSeriesData(
     filterFunc: Callable[[List[float], int, bool], List[float]],
     featureTimeList: List[list],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import io
 setup(
     name="praatio",
     python_requires=">3.6.0",
-    version="6.0.0",
+    version="6.1.0",
     author="Tim Mahrt",
     author_email="timmahrt@gmail.com",
     url="https://github.com/timmahrt/praatIO",

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -4,6 +4,9 @@ import unittest
 
 import pytest
 
+from praatio import textgrid
+from praatio.utilities.constants import Interval, INTERVAL_TIER, Point
+
 
 def areTheSameFiles(fn1, fn2, fileHandler, *args):
     """
@@ -43,3 +46,15 @@ class _DecoratedMethodsClass(type):
 
 class CoverageIgnoredTest(unittest.TestCase, metaclass=_DecoratedMethodsClass):
     pass
+
+
+def makeIntervalTier(name="words", intervals=None, minT=0, maxT=5.0):
+    if intervals is None:
+        intervals = [Interval(1, 2, "hello"), Interval(3.5, 4.0, "world")]
+    return textgrid.IntervalTier(name, intervals, minT, maxT)
+
+
+def makePointTier(name="pitch_values", points=None, minT=0, maxT=5.0):
+    if points is None:
+        points = [Point(1.3, "55"), Point(3.7, "99")]
+    return textgrid.PointTier(name, points, minT, maxT)

--- a/tutorials/tutorial1_intro_to_praatio.ipynb
+++ b/tutorials/tutorial1_intro_to_praatio.ipynb
@@ -175,7 +175,7 @@
     }
    ],
    "source": [
-    "!pip install praatio --upgrade"
+    "%pip install praatio --upgrade"
    ]
   },
   {


### PR DESCRIPTION
While working on a a bugfix for `praatio_scripts.alignBoundariesAcrossTiers` I thought it might be good to incorporate the new code directly into the tiers themselves.

---- 
I considered making an autodejitter--so having a tier use its own timepoints as the reference points, but after removing values within the tolerance range. I could maybe think of a situation for interval tiers but not point tiers. For the moment, I've decided not to implement anything.