### PR TITLE
fix: replace deprecated pkg_resources with importlib

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt-get install praat
           python -m pip install --upgrade pip
           pip install -U pip setuptools
           pip install "importlib-metadata>=4.12" coveralls pytest pytest-cov

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install praat
           python -m pip install --upgrade pip
           pip install -U pip setuptools
           pip install "importlib-metadata>=4.12" coveralls pytest pytest-cov

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ Please view [CHANGELOG.md](https://github.com/timmahrt/praatIO/blob/main/CHANGEL
 
 Python module `https://pypi.org/project/typing-extensions/`.  It should be installed automatically with praatio but you can install it manually if you have any problems.
 
-``Python 3.7.*`` or above
-
-[Click here to visit travis-ci and see the specific versions of python that praatIO is currently tested under](<https://travis-ci.org/timmahrt/praatIO>)
+``Python 3.7.*`` or above (CI tested with python `3.7` through `3.12`).
 
 If you are using ``Python 2.x`` or ``Python < 3.7``, you can use `PraatIO 4.x`.
 

--- a/examples/get_pitch_and_formants.py
+++ b/examples/get_pitch_and_formants.py
@@ -74,7 +74,7 @@ maryPitchData = pitch_and_intensity.extractPI(
     450,
     forceRegenerate=False,
 )
-tg = textgrid.openTextgrid(join(tgPath, "mary.TextGrid"))
+tg = textgrid.openTextgrid(join(tgPath, "mary.TextGrid"), False)
 tier = tg.getTier("phone")
 filteredData = tier.getValuesInIntervals(maryPitchData)
 

--- a/praatio/utilities/utils.py
+++ b/praatio/utilities/utils.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import itertools
 import wave
-import importlib.resources as pkg_resources
+from importlib import resources
 from typing_extensions import Literal
 from typing import Any, Iterator, List, Tuple, NoReturn, Type, Optional
 
@@ -16,11 +16,11 @@ from praatio.utilities import constants
 Interval = constants.Interval
 
 # New in python 3.9
-if hasattr(pkg_resources, "files"):
-    scriptsPath = pkg_resources.files("praatio") / "praatScripts"
+if hasattr(resources, "files"):
+    scriptsPath = resources.files("praatio") / "praatScripts"
 # Deprecated in python 3.11
 else:
-    scriptsPath = pkg_resources.path(
+    scriptsPath = resources.path(
         "praatio",
         "praatScripts",
     )

--- a/praatio/utilities/utils.py
+++ b/praatio/utilities/utils.py
@@ -20,10 +20,8 @@ if hasattr(resources, "files"):
     scriptsPath = resources.files("praatio") / "praatScripts"
 # Deprecated in python 3.11
 else:
-    scriptsPath = resources.path(
-        "praatio",
-        "praatScripts",
-    )
+    with resources.path("praatio", "praatScripts") as path:
+        scriptsPath = path
 
 
 def find(list, value, reverse) -> Optional[int]:

--- a/praatio/utilities/utils.py
+++ b/praatio/utilities/utils.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import itertools
 import wave
-from pkg_resources import resource_filename
+import importlib.resources as pkg_resources
 from typing_extensions import Literal
 from typing import Any, Iterator, List, Tuple, NoReturn, Type, Optional
 
@@ -15,11 +15,15 @@ from praatio.utilities import constants
 
 Interval = constants.Interval
 
-# Get the folder one level above the current folder
-scriptsPath = resource_filename(
-    "praatio",
-    "praatScripts",
-)
+# New in python 3.9
+if hasattr(pkg_resources, "files"):
+    scriptsPath = pkg_resources.files("praatio") / "praatScripts"
+# Deprecated in python 3.11
+else:
+    scriptsPath = pkg_resources.path(
+        "praatio",
+        "praatScripts",
+    )
 
 
 def find(list, value, reverse) -> Optional[int]:
@@ -386,7 +390,6 @@ def findAll(txt: str, subStr: str) -> List[int]:
 def runPraatScript(
     praatEXE: str, scriptFN: str, argList: List[Any], cwd: str = None
 ) -> None:
-
     # Popen gives a not-very-transparent error
     if not os.path.exists(praatEXE):
         raise errors.FileNotFound(praatEXE)


### PR DESCRIPTION
Fix for: https://github.com/timmahrt/praatIO/issues/58

pkg_resources is deprecated. One possibility is to use importlib.pkg_resources.path, but this was also deprecated in 3.11.  importlib.pkg_resources.files was added in 3.9.

So we'll use a combination of both to ensure users from 3.7~3.12 can use the code.

This PR does the following:
- remove deprecation warning for pkg_resources
- adds Python 3.12 to CI tests
- fixes missing argument caught in example script