### PR TITLE
fix: resolve post migration build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 
 *Praatio uses semantic versioning (Major.Minor.Patch)*
 
-Ver 6.2.1 (Nov 15, 2025)
+Ver 6.2.2 (Jan 16, 2025)
+- Migrate from setup.py to pyproject.toml
+
+Ver 6.2.1 (Jan 16, 2025)
 - Bugfix: sanitize input pointList data for PitchTier and DurationTier creation to avoid generating corrupt output files
 
 Ver 6.2 (Dec 10, 2023)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ packages = [
     "praatio.data_classes",
 ]
 
-[tool.hatch.build.targets.wheel.force-include]
-"praatio/praatScripts" = "praatio/praatScripts"
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Locally I get errors like this when I try to upload to pypi:

`Invalid distribution file. ZIP archive not accepted: Duplicate filename in local headers.`

Inspecting the contents of the built distribution file, there are indeed duplicate entries:
```
> unzip -l dist/praatio-6.2.2-py3-none-any.whl | grep praat
1082  02-02-2020 00:00   praatio/praatScripts/annotate_silences.praat
...
1082  02-02-2020 00:00   **praatio/praatScripts/annotate_silences.praat**
```

This PR resolves the issue.